### PR TITLE
Support fallback for restPrefix blueprint configuration

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -29,7 +29,8 @@ module.exports = function (sails) {
 
             if (!controller) return;
 
-            var baseRoute = [config.prefix, model.identity].join('/');
+            var prefix = config.restPrefix || config.prefix;
+            var baseRoute = [prefix, model.identity].join('/');
 
             if (config.pluralize && _.get(controller, '_config.pluralize', true)) {
               baseRoute = pluralize(baseRoute);


### PR DESCRIPTION
This will look for restPrefix first, then prefix if defined
