### PR TITLE
support both prefix and restPrefix

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -28,8 +28,28 @@ module.exports = function (sails) {
             var controller = sails.middleware.controllers[model.identity];
 
             if (!controller) return;
+	      // Validate blueprint config for this controller
+	    if ( config.prefix ) {
+              if ( !_(config.prefix).isString() ) {
+                return;
+              }
+              if ( !config.prefix.match(/^\//) ) {
+                config.prefix = '/' + config.prefix;
+              }
+            }
 
-            var prefix = config.restPrefix || config.prefix;
+            // Validate REST route blueprint config for this controller
+	    if ( config.restPrefix ) {
+              if ( !_(config.restPrefix).isString() ) {
+                return;
+              }
+              if ( !config.restPrefix.match(/^\//) ) {
+                config.restPrefix = '/' + config.restPrefix;
+              }
+            }
+
+	    var prefix = config.prefix + config.restPrefix;
+
             var baseRoute = [prefix, model.identity].join('/');
 
             if (config.pluralize && _.get(controller, '_config.pluralize', true)) {


### PR DESCRIPTION
Behave just like blueprints do in sails 0.12 
https://github.com/balderdashy/sails/blob/master/lib/hooks/blueprints/index.js
